### PR TITLE
Fix to allow Experiment.result() job parameter to be V1Job object or job name

### DIFF
--- a/lib/exp.py
+++ b/lib/exp.py
@@ -271,12 +271,19 @@ class Experiment(object):
 
     def result(self, job):
         status = {}
-        if 'job_parameters' in job.metadata.annotations:
-            status['job_parameters'] = json.loads(
-                job.metadata.annotations['job_parameters'])
+
+        if isinstance(job, client.models.V1Job):
+            job_name = job.metadata.name
+            if 'job_parameters' in job.metadata.annotations:
+                status['job_parameters'] = json.loads(
+                    job.metadata.annotations['job_parameters'])
+        elif isinstance(job, str):
+            job_name = job
+        else:
+            raise TypeError("Unsupported type {} for job.".format(type(job)))
 
         return Result(
-            job.metadata.name,
+            job_name,
             self.name,
             self.uid(),
             status=status


### PR DESCRIPTION
Fix for issue #28 

This change allows the `job` parameter to be either a V1Job object or a string job name.