### PR TITLE
Add and use get_job in job.py to extract job details

### DIFF
--- a/job.py
+++ b/job.py
@@ -20,7 +20,7 @@ def main():
     print('Starting job {} for experiment {}'.format(job_name, exp.name))
 
     try:
-        result = c.create_result(exp.result(job_name))
+        result = c.create_result(exp.result(c.get_job(job_name)))
     except kubernetes.client.rest.ApiException as e:
         body = json.loads(e.body)
         if body['reason'] != 'AlreadyExists':

--- a/lib/exp.py
+++ b/lib/exp.py
@@ -271,12 +271,19 @@ class Experiment(object):
 
     def result(self, job):
         status = {}
-        if 'job_parameters' in job.metadata.annotations:
-            status['job_parameters'] = json.loads(
-                job.metadata.annotations['job_parameters'])
+
+        if isinstance(job, client.models.V1Job):
+            job_name = job.metadata.name
+            if 'job_parameters' in job.metadata.annotations:
+                status['job_parameters'] = json.loads(
+                    job.metadata.annotations['job_parameters'])
+        elif isinstance(job, str):
+            job_name = job
+        else:
+            raise TypeError("Unsupported type {} for job.".format(type(job)))
 
         return Result(
-            job.metadata.name,
+            job_name,
             self.name,
             self.uid(),
             status=status


### PR DESCRIPTION
Fix for issue #28

This change allows the `Experiment.result()` `job` parameter to be either a V1Job object or a string job name.