### PR TITLE
Update example/demo role to allow creating jobs

### DIFF
--- a/examples/demo/sa.yaml
+++ b/examples/demo/sa.yaml
@@ -10,6 +10,9 @@ rules:
 - apiGroups: ["ml.intel.com"]
   resources: ["results"]
   verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["*"]
 ---
 # experiment CRD role binding
 kind: RoleBinding


### PR DESCRIPTION
This is required if the optimizer is run from Kubernetes, to allow creating jobs in the namespace.